### PR TITLE
SB-41: Add  Form and Input Components with Validators

### DIFF
--- a/app/components/UI/Card/Card.stories.tsx
+++ b/app/components/UI/Card/Card.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Card from './Card';
+
+const meta = {
+	title: 'UI/Card',
+	component: Card,
+	parameters: {},
+	tags: ['autodocs'],
+	argTypes: {},
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+	args: {
+		children: 'Test',
+	},
+};

--- a/app/components/UI/Card/Card.tsx
+++ b/app/components/UI/Card/Card.tsx
@@ -1,0 +1,11 @@
+type Props = {
+	children: React.ReactNode;
+};
+
+export default function Card({ children }: Props) {
+	return (
+		<div className='card'>
+			<div className='card-body'>{children}</div>
+		</div>
+	);
+}

--- a/app/components/UI/Form/Form.css
+++ b/app/components/UI/Form/Form.css
@@ -1,0 +1,8 @@
+.form__buttons {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.form__button {
+	margin: 2px;
+}

--- a/app/components/UI/Form/Form.tsx
+++ b/app/components/UI/Form/Form.tsx
@@ -1,0 +1,82 @@
+import { FormEvent } from 'react';
+import { FieldValues, FormProvider, useForm } from 'react-hook-form';
+import './Form.css';
+
+const LABELS = {
+	SUBMIT: 'Guardar',
+	CANCEL: 'Cancelar',
+};
+
+type Props = {
+	children: React.ReactNode;
+	title: string;
+	initialValues: FieldValues;
+	handleSubmit: (data: unknown) => void;
+	handleCancel: () => void;
+	disabled?: boolean;
+	setDisabled?: (state: boolean) => void;
+};
+
+export default function Form({
+	children,
+	title,
+	initialValues,
+	setDisabled = () => {},
+	handleSubmit,
+	handleCancel,
+	disabled = false,
+}: Props) {
+	const methods = useForm({
+		mode: 'onChange',
+		values: initialValues,
+	});
+
+	const formSubmit = methods.handleSubmit(data => {
+		handleSubmit(data);
+	});
+
+	const onCancel = () => {
+		methods.reset();
+		setDisabled(true);
+		handleCancel();
+	};
+
+	const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		formSubmit();
+	};
+
+	return (
+		<FormProvider {...methods}>
+			<form onSubmit={e => onSubmit(e)} noValidate>
+				<fieldset disabled={disabled}>
+					<legend>
+						{title}
+						{disabled && (
+							<button type='button' onClick={() => setDisabled(false)}>
+								Editar
+							</button>
+						)}
+					</legend>
+					{children}
+					{!disabled && (
+						<div className='form__buttons'>
+							<input
+								type='submit'
+								className='btn btn-primary form__button'
+								value={LABELS.SUBMIT}
+							/>
+							<button
+								type='button'
+								className='btn btn-secondary form__button'
+								onClick={onCancel}
+							>
+								{LABELS.CANCEL}
+							</button>
+						</div>
+					)}
+				</fieldset>
+			</form>
+		</FormProvider>
+	);
+}

--- a/app/components/UI/Input/Input.css
+++ b/app/components/UI/Input/Input.css
@@ -1,0 +1,7 @@
+.input__container {
+	max-width: 20rem;
+}
+
+.input__error {
+	color: red;
+}

--- a/app/components/UI/Input/Input.stories.tsx
+++ b/app/components/UI/Input/Input.stories.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable no-console */
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import {
+	TEXT_VALIDATOR,
+	NUMBER_VALIDATOR,
+	EMAIL_VALIDATOR,
+} from '../../../utils/Form/inputValidators';
+import Form from '../Form/Form';
+import Input from './Input';
+
+const meta = {
+	title: 'UI/Form/Input',
+	component: Form,
+	parameters: {},
+	tags: [],
+	argTypes: {},
+} satisfies Meta<typeof Form>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const InputsWithValidators: Story = {
+	decorators: [
+		() => {
+			const initialValues = {
+				firstName: 'Pepe',
+				lastName: null,
+				age: '23',
+				email: 'test@mail.com',
+			};
+
+			const handleSubmit = (data: unknown) => {
+				console.log(data);
+				// eslint-disable-next-line no-alert
+				alert(JSON.stringify(data));
+			};
+
+			const [disabled, setDisabled] = useState<boolean>(true);
+			return (
+				<Form
+					title='Form With Inputs'
+					initialValues={initialValues}
+					handleSubmit={handleSubmit}
+					handleCancel={() => {
+						console.log('Cancel');
+					}}
+					disabled={disabled}
+					setDisabled={setDisabled}
+				>
+					<Input
+						label='Firstname'
+						id='input-field-firstname'
+						placeholder='...'
+						name='firstName'
+						{...TEXT_VALIDATOR}
+					/>
+					<Input
+						label='Lastname'
+						id='input-field-lastname'
+						placeholder='...'
+						name='lastName'
+						{...TEXT_VALIDATOR}
+					/>
+					<Input
+						label='Age'
+						id='input-field-age'
+						placeholder=''
+						name='age'
+						{...NUMBER_VALIDATOR}
+					/>
+					<Input
+						label='Email'
+						id='input-field-email'
+						placeholder='...'
+						name='email'
+						{...EMAIL_VALIDATOR}
+					/>
+				</Form>
+			);
+		},
+	],
+};

--- a/app/components/UI/Input/Input.tsx
+++ b/app/components/UI/Input/Input.tsx
@@ -1,0 +1,53 @@
+import { RegisterOptions, useFormContext } from 'react-hook-form';
+import { findInputError, isFormInvalid } from '../../../utils/Form/formHelper';
+import './Input.css';
+
+type Props = {
+	label: string;
+	type: string;
+	id: string;
+	placeholder: string;
+	name: string;
+	validation: RegisterOptions;
+	showCurrency?: boolean;
+};
+
+function InputError({ message }: { message: string }) {
+	return <p className='input__error'>{message}</p>;
+}
+
+export default function Input({
+	label,
+	type,
+	id,
+	placeholder,
+	validation,
+	name,
+	showCurrency = false,
+}: Props) {
+	const {
+		register,
+		formState: { errors },
+	} = useFormContext();
+	const inputError = findInputError(errors, name);
+	const isInvalid = isFormInvalid(inputError);
+
+	return (
+		<div className='mb-3'>
+			<label htmlFor={id} className='form-label'>
+				{label}
+			</label>
+			<div className='input-group input__container'>
+				{showCurrency && <span className='input-group-text'>$</span>}
+				<input
+					id={id}
+					type={type}
+					className='form-control'
+					placeholder={placeholder}
+					{...register(name, validation)}
+				/>
+			</div>
+			{isInvalid && <InputError message={inputError.error.message} />}
+		</div>
+	);
+}

--- a/app/utils/Form/formHelper.ts
+++ b/app/utils/Form/formHelper.ts
@@ -1,0 +1,14 @@
+import { FieldErrors } from 'react-hook-form';
+
+export const isFormInvalid = (err: FieldErrors) => {
+	if (Object.keys(err).length > 0) return true;
+	return false;
+};
+
+export function findInputError(errors: FieldErrors, name: string): FieldErrors {
+	const filtered = Object.keys(errors)
+		.filter(key => key.includes(name))
+		.reduce((cur, key) => Object.assign(cur, { error: errors[key] }), {});
+
+	return filtered;
+}

--- a/app/utils/Form/inputValidators.ts
+++ b/app/utils/Form/inputValidators.ts
@@ -1,0 +1,77 @@
+export const TEXT_VALIDATOR = {
+	type: 'text',
+	validation: {
+		required: {
+			value: true,
+			message: 'texto requerido',
+		},
+		maxLength: {
+			value: 30,
+			message: 'máximo 30 caracteres',
+		},
+	},
+};
+
+export const HOUR_VALIDATOR = {
+	type: 'text',
+	validation: {
+		required: {
+			value: true,
+			message: 'hora requerida',
+		},
+		pattern: {
+			value: /^([0-1]?[0-9]|2[0-3]):[0][0]$/,
+			message: 'formato no válido',
+		},
+	},
+};
+
+export const PASSWORD_VALIDATOR = {
+	type: 'password',
+	validation: {
+		required: {
+			value: true,
+			message: 'required',
+		},
+		minLength: {
+			value: 6,
+			message: 'min 6 characters',
+		},
+	},
+};
+
+export const PRICE_VALIDATOR = {
+	showCurrency: true,
+	type: 'number',
+	validation: {
+		required: {
+			value: true,
+			message: 'precio requerido',
+		},
+	},
+};
+
+export const NUMBER_VALIDATOR = {
+	type: 'number',
+	validation: {
+		required: {
+			value: true,
+			message: 'número requerido',
+		},
+	},
+};
+
+export const EMAIL_VALIDATOR = {
+	type: 'email',
+	validation: {
+		required: {
+			value: true,
+			message: 'required',
+		},
+		pattern: {
+			value:
+				/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+			message: 'not valid',
+		},
+	},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"react": "^18",
 				"react-day-picker": "^8.10.0",
 				"react-dom": "^18",
+				"react-hook-form": "^7.50.1",
 				"react-toastify": "^10.0.4",
 				"storybook": "^7.6.13"
 			},
@@ -14972,6 +14973,21 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
 			"integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
 			"dev": true
+		},
+		"node_modules/react-hook-form": {
+			"version": "7.50.1",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
+			"integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-hook-form"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17 || ^18"
+			}
 		},
 		"node_modules/react-is": {
 			"version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"react": "^18",
 		"react-day-picker": "^8.10.0",
 		"react-dom": "^18",
+		"react-hook-form": "^7.50.1",
 		"react-toastify": "^10.0.4",
 		"storybook": "^7.6.13"
 	},


### PR DESCRIPTION
Changes:
* Add React-Form-Hook library to manage the logic for the forms within the project
* Add Form Component
* Add Input Component
* Add Validation logic for the different types of inputs (text, price, number, email, etc).

Extra:
* Add Card Component

Form Component in disabled mode (only show the current information):
![image](https://github.com/EzeLamar/sports-booking/assets/26080561/927b7eb3-ffcf-4a6f-949c-3ed0c62917b8)

Form Component in enabled mode:
* allow edit the fields and submitting the changes
* When we press the cancel button the form is reset with the default values. Also, change its state to disabled

![image](https://github.com/EzeLamar/sports-booking/assets/26080561/b5f12f40-2bfb-4365-a073-aeb1fa8c88fa)
