### PR TITLE
SB-45: Get Set Court Settings from Firebase

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {

--- a/app/admin/court/CourtSettingsView.tsx
+++ b/app/admin/court/CourtSettingsView.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import CourtSettings, {
+	Court,
+} from '../../components/Courts/CourtSettings/CourtSettings';
+import { getCourt, editCourt } from '../../firebase/courts/courts';
+import Loading from '../../components/UI/Loading/Loading';
+import 'react-toastify/dist/ReactToastify.css';
+
+export default function CourtSettingsView() {
+	const [court, setCourt] = useState<Court | null>(null);
+	const [loading, setLoading] = useState<boolean>(true);
+
+	const handleSubmit = (data: Court): Promise<boolean> => {
+		const editData = async () => {
+			try {
+				const result = await editCourt(data);
+				toast.success('Cancha actualizada!', {
+					theme: 'colored',
+				});
+				setCourt(data);
+
+				return result;
+			} catch (error) {
+				toast.error(error.message, { theme: 'colored' });
+
+				throw error;
+			}
+		};
+
+		return editData();
+	};
+
+	useEffect((): void => {
+		const fetchData = async () => {
+			try {
+				const courtData = await getCourt();
+				setCourt(courtData);
+				setLoading(false);
+			} catch (error) {
+				toast.error(error.message, { theme: 'colored' });
+			}
+		};
+
+		fetchData();
+	}, []);
+
+	return (
+		<div>
+			{loading ? (
+				<Loading />
+			) : (
+				<CourtSettings court={court} handleSubmit={handleSubmit} />
+			)}
+		</div>
+	);
+}

--- a/app/admin/court/page.tsx
+++ b/app/admin/court/page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuthContext } from '../context/AuthContext';
-import Loading from '../components/UI/Loading/Loading';
+import { useAuthContext } from '../../context/AuthContext';
+import CourtSettingsView from './CourtSettingsView';
+import Loading from '../../components/UI/Loading/Loading';
 
-export default function AdminPage() {
+export default function CourtPage() {
 	const user = useAuthContext();
 	const router = useRouter();
 
@@ -19,8 +20,8 @@ export default function AdminPage() {
 		<Loading />
 	) : (
 		<>
-			<h2>Admin View: Hi {user.email}</h2>
-			<p>Only logged in users can view this page</p>
+			<h2>Court View: Hi {user.email}</h2>
+			<CourtSettingsView />
 		</>
 	);
 }

--- a/app/components/Courts/CourtSettings/CourtSettings.stories.tsx
+++ b/app/components/Courts/CourtSettings/CourtSettings.stories.tsx
@@ -23,12 +23,15 @@ const court: Court = {
 	closeHour: '16:00',
 };
 
-const handleSubmit = (data: unknown) => {
-	// eslint-disable-next-line no-console
-	console.log(data);
-	// eslint-disable-next-line no-alert
-	alert(JSON.stringify(data));
-};
+const handleSubmit = (data: unknown): Promise<boolean> =>
+	new Promise(resolve => {
+		// eslint-disable-next-line no-console
+		console.log(data);
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify(data));
+		resolve(true);
+	});
+
 const handleCancel = () => {
 	// eslint-disable-next-line no-console
 	console.log('Cancel Button');

--- a/app/components/Courts/CourtSettings/CourtSettings.tsx
+++ b/app/components/Courts/CourtSettings/CourtSettings.tsx
@@ -23,9 +23,8 @@ export type Court = {
 
 type Props = {
 	court: Court | null;
-	editable: boolean;
-	handleSubmit: (data: unknown) => void;
-	handleCancel: () => void;
+	handleSubmit: (data: Court) => Promise<boolean>;
+	editable?: boolean;
 };
 
 const LABELS = {
@@ -52,7 +51,6 @@ export default function CourtSettings({
 	court = null,
 	editable = false,
 	handleSubmit,
-	handleCancel,
 }: Props) {
 	const [disabled, setDisabled] = useState<boolean>(!editable);
 	const formValues = { ...court };
@@ -65,7 +63,6 @@ export default function CourtSettings({
 				setDisabled={setDisabled}
 				initialValues={formValues}
 				handleSubmit={handleSubmit}
-				handleCancel={handleCancel}
 			>
 				<Input
 					id='court-settings-name'

--- a/app/components/UI/Form/Form.css
+++ b/app/components/UI/Form/Form.css
@@ -6,3 +6,7 @@
 .form__button {
 	margin: 2px;
 }
+
+.form__edit-button {
+	margin-left: 1rem;
+}

--- a/app/components/UI/Form/Form.tsx
+++ b/app/components/UI/Form/Form.tsx
@@ -11,9 +11,10 @@ type Props = {
 	children: React.ReactNode;
 	title: string;
 	initialValues: FieldValues;
-	handleSubmit: (data: unknown) => void;
-	handleCancel: () => void;
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	handleSubmit: (data: any) => Promise<boolean>;
 	disabled?: boolean;
+	handleCancel?: () => void;
 	setDisabled?: (state: boolean) => void;
 };
 
@@ -21,18 +22,14 @@ export default function Form({
 	children,
 	title,
 	initialValues,
-	setDisabled = () => {},
 	handleSubmit,
-	handleCancel,
 	disabled = false,
+	handleCancel = () => {},
+	setDisabled = () => {},
 }: Props) {
 	const methods = useForm({
 		mode: 'onChange',
 		values: initialValues,
-	});
-
-	const formSubmit = methods.handleSubmit(data => {
-		handleSubmit(data);
 	});
 
 	const onCancel = () => {
@@ -40,6 +37,12 @@ export default function Form({
 		setDisabled(true);
 		handleCancel();
 	};
+
+	const formSubmit = methods.handleSubmit(data => {
+		handleSubmit(data)
+			.then(() => setDisabled(true))
+			.catch(() => onCancel());
+	});
 
 	const onSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -49,15 +52,17 @@ export default function Form({
 	return (
 		<FormProvider {...methods}>
 			<form onSubmit={e => onSubmit(e)} noValidate>
+				<legend>
+					{title}
+					{disabled && (
+						<button
+							className='btn btn-outline-primary bi bi-pencil-fill'
+							type='button'
+							onClick={() => setDisabled(false)}
+						/>
+					)}
+				</legend>
 				<fieldset disabled={disabled}>
-					<legend>
-						{title}
-						{disabled && (
-							<button type='button' onClick={() => setDisabled(false)}>
-								Editar
-							</button>
-						)}
-					</legend>
 					{children}
 					{!disabled && (
 						<div className='form__buttons'>

--- a/app/components/UI/Input/Input.stories.tsx
+++ b/app/components/UI/Input/Input.stories.tsx
@@ -35,12 +35,13 @@ export const InputsWithValidators: Story = {
 				days: ['tuesday'],
 			};
 
-			const handleSubmit = (data: unknown) => {
-				console.log(data);
-				// eslint-disable-next-line no-alert
-				alert(JSON.stringify(data));
-				setDisabled(true);
-			};
+			const handleSubmit = (data: unknown): Promise<boolean> =>
+				new Promise(resolve => {
+					console.log(data);
+					// eslint-disable-next-line no-alert
+					alert(JSON.stringify(data));
+					resolve(true);
+				});
 
 			return (
 				<Form

--- a/app/components/UI/Navbar/Navbar.tsx
+++ b/app/components/UI/Navbar/Navbar.tsx
@@ -56,7 +56,12 @@ export default function NavBar() {
 						</li>
 						<li className='nav-item'>
 							<Link className='nav-link' href='/admin'>
-								Test logged user
+								Admin
+							</Link>
+						</li>
+						<li className='nav-item'>
+							<Link className='nav-link' href='/admin/court'>
+								Court Settings
 							</Link>
 						</li>
 						<li className='nav-item'>

--- a/app/firebase/courts/courts.ts
+++ b/app/firebase/courts/courts.ts
@@ -1,0 +1,40 @@
+import { getFirestore, doc, getDoc, updateDoc } from 'firebase/firestore';
+import { Court } from '@/app/components/Courts/CourtSettings/CourtSettings';
+import firebaseApp from '../config';
+
+export async function getCourt(): Promise<Court> {
+	const db = getFirestore(firebaseApp);
+	const docRef = doc(
+		db,
+		process.env.NEXT_PUBLIC_COURT_COLLECTION,
+		process.env.NEXT_PUBLIC_BURATO_COURT_ID
+	);
+
+	const docSnap = await getDoc(docRef);
+	if (!docSnap.exists()) {
+		throw new Error('The court does not exist.');
+	}
+
+	const data = { ...docSnap.data() };
+	return {
+		isEnabled: data.enabled,
+		name: data.name,
+		address: data.address,
+		availableDays: data.availableDays,
+		openHour: data.openHour,
+		closeHour: data.closeHour,
+		pricePerHour: data.pricePerHour,
+	};
+}
+
+export async function editCourt(court: Court): Promise<boolean> {
+	const db = getFirestore(firebaseApp);
+	const docRef = doc(
+		db,
+		process.env.NEXT_PUBLIC_COURT_COLLECTION,
+		process.env.NEXT_PUBLIC_BURATO_COURT_ID
+	);
+	await updateDoc(docRef, court);
+
+	return true;
+}


### PR DESCRIPTION
Changes:
* Add queries to get and set a specific Court in Firebase.
* Form component:
  * Add a pencil icon in the Edit button of the Form component
  
![image](https://github.com/EzeLamar/sports-booking/assets/26080561/3503d055-f6b7-4494-9efc-9b543c144fd4)

  * move the title and edit button out of the **fieldset** to avoid the edit button has a disable state when the form is disabled.
  * add logic to disable the form when the onSubmit promise finishes successfully.
  * Update Input Price validation to avoid numbers less than 1.
* Add view for CourtSettings.