### PR TITLE
SB-3: Add Vercel Speed Insights for Deploy Metrics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ToastContainer } from 'react-toastify';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { AuthContextProvider } from './context/AuthContext';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
@@ -31,6 +32,7 @@ export default function RootLayout({
 					<NavBar />
 					{children}
 				</AuthContextProvider>
+				<SpeedInsights />
 			</body>
 		</html>
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "sport-booking",
 			"version": "0.1.0",
 			"dependencies": {
+				"@vercel/speed-insights": "^1.0.10",
 				"bootstrap": "^5.3.2",
 				"bootstrap-icons": "^1.11.3",
 				"date-fns": "^3.3.1",
@@ -6728,6 +6729,40 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
 			"dev": true
+		},
+		"node_modules/@vercel/speed-insights": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.10.tgz",
+			"integrity": "sha512-4uzdKB0RW6Ff2FkzshzjZ+RlJfLPxgm/00i0XXgxfMPhwnnsk92YgtqsxT9OcPLdJUyVU1DqFlSWWjIQMPkh0g==",
+			"hasInstallScript": true,
+			"peerDependencies": {
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"react": "^18 || ^19",
+				"svelte": "^4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@vitest/expect": {
 			"version": "0.34.7",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"tsc:check": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@vercel/speed-insights": "^1.0.10",
 		"bootstrap": "^5.3.2",
 		"bootstrap-icons": "^1.11.3",
 		"date-fns": "^3.3.1",


### PR DESCRIPTION
Add Speed-Insights Library to start collecting performance metrics after the Vercel Deploy