### PR TITLE
SB-62: Add Reservation Modal Component

### DIFF
--- a/app/components/Reservations/ReservationForm.stories.tsx
+++ b/app/components/Reservations/ReservationForm.stories.tsx
@@ -1,9 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import moment from 'moment';
-import ReservationForm, {
-	InitialReservation,
-	Reservation,
-} from './ReservationForm';
+import ReservationForm, { Reservation } from './ReservationForm';
+import {
+	EMPTY_RESERVATION,
+	RESERVATION,
+	RESERVATION_START_TIME,
+	RESERVATION_WITHOUT_END_TIME,
+} from './values';
 
 const meta = {
 	title: 'Reservations/ReservationForm',
@@ -17,33 +19,6 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const now = new Date();
-const reservationStartTime = new Date(
-	now.getFullYear(),
-	now.getMonth(),
-	now.getDate(),
-	14,
-	0
-);
-
-const reservation: InitialReservation = {
-	owner: 'John Doe',
-	startTime: reservationStartTime,
-	endTime: moment(reservationStartTime).add(90, 'minutes').toDate(),
-};
-
-const reservationWithoutEndTime: InitialReservation = {
-	owner: 'John Doe',
-	startTime: reservationStartTime,
-	endTime: null,
-};
-
-const emptyReservation: InitialReservation = {
-	owner: '',
-	startTime: null,
-	endTime: null,
-};
-
 const handleSubmit = (data: Reservation): Promise<boolean> =>
 	new Promise(resolve => {
 		// eslint-disable-next-line no-console
@@ -55,39 +30,39 @@ const handleSubmit = (data: Reservation): Promise<boolean> =>
 
 export const Enabled: Story = {
 	args: {
-		reservation,
+		reservation: RESERVATION,
 		editable: true,
 		handleSubmit,
-		minDate: reservationStartTime,
-		maxDate: reservationStartTime,
+		minDate: RESERVATION_START_TIME,
+		maxDate: RESERVATION_START_TIME,
 	},
 };
 
 export const Disabled: Story = {
 	args: {
-		reservation,
+		reservation: RESERVATION,
 		handleSubmit,
-		minDate: reservationStartTime,
-		maxDate: reservationStartTime,
+		minDate: RESERVATION_START_TIME,
+		maxDate: RESERVATION_START_TIME,
 	},
 };
 
 export const Empty: Story = {
 	args: {
-		reservation: emptyReservation,
+		reservation: EMPTY_RESERVATION,
 		editable: true,
 		handleSubmit,
-		minDate: reservationStartTime,
-		maxDate: reservationStartTime,
+		minDate: RESERVATION_START_TIME,
+		maxDate: RESERVATION_START_TIME,
 	},
 };
 
 export const MissingEndTime: Story = {
 	args: {
-		reservation: reservationWithoutEndTime,
+		reservation: RESERVATION_WITHOUT_END_TIME,
 		editable: true,
 		handleSubmit,
-		minDate: reservationStartTime,
-		maxDate: reservationStartTime,
+		minDate: RESERVATION_START_TIME,
+		maxDate: RESERVATION_START_TIME,
 	},
 };

--- a/app/components/Reservations/ReservationForm.tsx
+++ b/app/components/Reservations/ReservationForm.tsx
@@ -35,17 +35,21 @@ export type InitialReservation = {
 type Props = {
 	reservation: InitialReservation;
 	handleSubmit: (data: Reservation) => Promise<boolean>;
+	handleCancel: () => void;
 	minDate?: Date | null;
 	maxDate?: Date | null;
 	editable?: boolean;
+	showTitle?: boolean;
 };
 
 export default function ReservationForm({
 	reservation,
 	handleSubmit,
+	handleCancel = () => {},
 	editable = false,
 	minDate = null,
 	maxDate = null,
+	showTitle = true,
 }: Props) {
 	const [disabled, setDisabled] = useState<boolean>(!editable);
 	const min = minDate ? moment(minDate).format(MIN_DATE_FORMAT) : undefined;
@@ -92,9 +96,10 @@ export default function ReservationForm({
 
 	return (
 		<Form
-			title={LABELS.FORM_TITLE}
+			title={showTitle ? LABELS.FORM_TITLE : null}
 			initialValues={initialValues}
 			handleSubmit={onSubmit}
+			handleCancel={handleCancel}
 			disabled={disabled}
 			setDisabled={setDisabled}
 		>

--- a/app/components/Reservations/ReservationModal.stories.tsx
+++ b/app/components/Reservations/ReservationModal.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ReservationModal from './ReservationModal';
+import {
+	EMPTY_RESERVATION,
+	RESERVATION,
+	RESERVATION_WITHOUT_END_TIME,
+} from './values';
+import { Reservation } from './ReservationForm';
+
+const meta = {
+	title: 'Reservations/ReservationModal',
+	component: ReservationModal,
+	parameters: {},
+	tags: [],
+	argTypes: {},
+} satisfies Meta<typeof ReservationModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const now = new Date();
+const reservationStartTime = new Date(
+	now.getFullYear(),
+	now.getMonth(),
+	now.getDate(),
+	14,
+	0
+);
+
+const handleSubmit = (data: Reservation): Promise<boolean> =>
+	new Promise(resolve => {
+		// eslint-disable-next-line no-console
+		console.log(data);
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify(data));
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify('se cierra el modal'));
+		resolve(true);
+	});
+
+const handleClose = (): void => {
+	// eslint-disable-next-line no-alert
+	alert(JSON.stringify('se cierra el modal'));
+};
+
+export const Enabled: Story = {
+	args: {
+		show: true,
+		reservation: RESERVATION,
+		editable: true,
+		handleSubmit,
+		handleClose,
+		handleCancel: handleClose,
+		minDate: reservationStartTime,
+		maxDate: reservationStartTime,
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		show: true,
+		reservation: RESERVATION,
+		handleSubmit,
+		handleClose,
+		minDate: reservationStartTime,
+		maxDate: reservationStartTime,
+	},
+};
+
+export const Empty: Story = {
+	args: {
+		show: true,
+		reservation: EMPTY_RESERVATION,
+		editable: true,
+		handleSubmit,
+		handleClose,
+		handleCancel: handleClose,
+		minDate: reservationStartTime,
+		maxDate: reservationStartTime,
+	},
+};
+
+export const MissingEndTime: Story = {
+	args: {
+		show: true,
+		reservation: RESERVATION_WITHOUT_END_TIME,
+		editable: true,
+		handleSubmit,
+		handleCancel: handleClose,
+		minDate: reservationStartTime,
+		maxDate: reservationStartTime,
+	},
+};

--- a/app/components/Reservations/ReservationModal.tsx
+++ b/app/components/Reservations/ReservationModal.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Modal from '../UI/Modal/Modal';
+import ReservationForm, {
+	InitialReservation,
+	Reservation,
+} from './ReservationForm';
+
+const LABELS = {
+	MODAL_TITLE: 'Reserva:',
+};
+
+type Props = {
+	show: boolean;
+	reservation: InitialReservation;
+	handleClose: () => void;
+	handleSubmit: (data: Reservation) => Promise<boolean>;
+	handleCancel: () => void;
+	minDate?: Date | null;
+	maxDate?: Date | null;
+	editable?: boolean;
+};
+
+export default function ReservationModal({
+	show,
+	reservation,
+	handleSubmit,
+	handleClose,
+	handleCancel = () => {},
+	editable = false,
+	minDate = null,
+	maxDate = null,
+}: Props) {
+	return (
+		<Modal
+			show={show}
+			title={LABELS.MODAL_TITLE}
+			onClose={() => handleClose()}
+			showFooter={false}
+		>
+			<ReservationForm
+				reservation={reservation}
+				handleSubmit={handleSubmit}
+				handleCancel={handleCancel}
+				editable={editable}
+				minDate={minDate}
+				maxDate={maxDate}
+				showTitle={false}
+			/>
+		</Modal>
+	);
+}

--- a/app/components/Reservations/values.ts
+++ b/app/components/Reservations/values.ts
@@ -1,0 +1,29 @@
+import moment from 'moment';
+import { InitialReservation } from './ReservationForm';
+
+const now = new Date();
+export const RESERVATION_START_TIME = new Date(
+	now.getFullYear(),
+	now.getMonth(),
+	now.getDate(),
+	14,
+	0
+);
+
+export const RESERVATION: InitialReservation = {
+	owner: 'John Doe',
+	startTime: RESERVATION_START_TIME,
+	endTime: moment(RESERVATION_START_TIME).add(90, 'minutes').toDate(),
+};
+
+export const RESERVATION_WITHOUT_END_TIME: InitialReservation = {
+	owner: 'John Doe',
+	startTime: RESERVATION_START_TIME,
+	endTime: null,
+};
+
+export const EMPTY_RESERVATION: InitialReservation = {
+	owner: '',
+	startTime: null,
+	endTime: null,
+};


### PR DESCRIPTION
Changes:
* Add `ReservationModal` using the `Modal` and `ReservationForm` components.
* Add the Stories for `ReservationModal` taking as an example the `ReservationForm` Stories.

![image](https://github.com/EzeLamar/sports-booking/assets/26080561/d326d586-5d96-480b-8696-dca8b185eac4)
![image](https://github.com/EzeLamar/sports-booking/assets/26080561/ce4a1f8d-6c6a-4253-9466-8c3aeae72054)


Extra:
* Storybook:
  * Move the reservation mock values shared between the `ReservationForm `and `ReservationModal` Stories to a new file (`values.ts`)