### PR TITLE
SB-69: Refactor Courts Lists View

### DIFF
--- a/app/(admin)/courts/[id]/CourtSettingsView.tsx
+++ b/app/(admin)/courts/[id]/CourtSettingsView.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
-import hasErrorMessage from '../../utils/Error/ErrorHelper';
+import hasErrorMessage from '../../../utils/Error/ErrorHelper';
 import CourtSettings, {
 	Court,
-} from '../../components/Courts/CourtSettings/CourtSettings';
-import { getCourt, editCourt } from '../../firebase/courts/courts';
-import Loading from '../../components/UI/Loading/Loading';
+} from '../../../components/Courts/CourtSettings/CourtSettings';
+import { getCourt, editCourt } from '../../../firebase/courts/courts';
+import Loading from '../../../components/UI/Loading/Loading';
 
 type Props = {
 	courtId: string;

--- a/app/(admin)/courts/[id]/page.tsx
+++ b/app/(admin)/courts/[id]/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Loading from '../../../components/UI/Loading/Loading';
 import { useAuthContext } from '../../../context/AuthContext';
-import CourtSettingsView from '../CourtSettingsView';
+import CourtSettingsView from './CourtSettingsView';
 
 export default function CourtView({ params }: { params: { id: string } }) {
 	const user = useAuthContext();

--- a/app/(admin)/courts/page.tsx
+++ b/app/(admin)/courts/page.tsx
@@ -3,26 +3,23 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
-import Link from 'next/link';
-import { useAuthContext } from '../../context/AuthContext';
+import CourtCard from '@/app/components/Courts/CourtCard';
 import Loading from '../../components/UI/Loading/Loading';
 import hasErrorMessage from '../../utils/Error/ErrorHelper';
 import { Court } from '../../components/Courts/CourtSettings/CourtSettings';
 import { getAllCourts } from '../../firebase/courts/courts';
 
 export default function CourtsView() {
-	const user = useAuthContext();
 	const router = useRouter();
 	const [courts, setCourts] = useState<Array<Court>>([]);
+	const [loading, setLoading] = useState<boolean>(true);
 
 	useEffect((): void => {
-		if (!user) {
-			router.push('/signin');
-		}
 		const fetchData = async () => {
 			try {
 				const courtsData = await getAllCourts();
 				setCourts(courtsData);
+				setLoading(false);
 			} catch (error: unknown) {
 				if (hasErrorMessage(error)) {
 					toast.error(error.message, { theme: 'colored' });
@@ -30,22 +27,15 @@ export default function CourtsView() {
 			}
 		};
 		fetchData();
-	}, [user, router]);
+	}, [router]);
 
-	return !user ? (
+	return loading ? (
 		<Loading />
 	) : (
-		<>
-			<h2>List of courts</h2>
-			<ul>
-				{courts.map(court => (
-					<li key={court.id}>
-						<Link href={`/courts/${court.id}`}>
-							{court.id} - {court.name}
-						</Link>
-					</li>
-				))}
-			</ul>
-		</>
+		<div className='d-flex gap-3 flex-wrap flex-sm-row flex-column align-items-center justify-content-around'>
+			{courts.map(court => (
+				<CourtCard key={court.id} name={court.name} id={court.id} />
+			))}
+		</div>
 	);
 }

--- a/app/(admin)/reservations/[id]/page.tsx
+++ b/app/(admin)/reservations/[id]/page.tsx
@@ -5,7 +5,11 @@ import { Views } from 'react-big-calendar';
 import { useState } from 'react';
 import Calendar from '@/app/components/UI/Calendar/Calendar';
 
-export default function AdminPage() {
+type Props = {
+	params: { id: string };
+};
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function AdminPage({ params }: Props) {
 	const [showAll, setShowAll] = useState(false);
 	const minHour = !showAll ? moment('2024-04-04T09:00:00').toDate() : null;
 	const maxHour = !showAll ? moment('2024-04-04T23:00:00').toDate() : null;

--- a/app/components/Courts/CourtCard.tsx
+++ b/app/components/Courts/CourtCard.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import React from 'react';
+
+type Props = {
+	name: string;
+	id: string;
+};
+function CourtCard({ name, id }: Props) {
+	return (
+		<div className='card bg-light' style={{ width: '18rem' }}>
+			<div className='card-body'>
+				<h5 className='card-title'>{name}</h5>
+			</div>
+			<div className='card-body d-flex flex-row justify-content-between m-2'>
+				<Link className='btn btn-primary' href={`/reservations/${id}`}>
+					Reservas
+				</Link>
+				<Link className='btn btn-outline-primary' href={`/courts/${id}`}>
+					Ajustes
+				</Link>
+			</div>
+		</div>
+	);
+}
+
+export default CourtCard;

--- a/app/components/UI/Navbar/Navbar.tsx
+++ b/app/components/UI/Navbar/Navbar.tsx
@@ -60,24 +60,14 @@ export default function NavBar() {
 							</Link>
 						</li>
 						{user && (
-							<>
-								<li className='nav-item'>
-									<Link
-										className={`nav-link ${pathName === '/courts' ? 'active' : ''}`}
-										href='/courts'
-									>
-										Courts List
-									</Link>
-								</li>
-								<li className='nav-item'>
-									<Link
-										className={`nav-link ${pathName === '/reservations' ? 'active' : ''}`}
-										href='/reservations'
-									>
-										Reservations
-									</Link>
-								</li>
-							</>
+							<li className='nav-item'>
+								<Link
+									className={`nav-link ${pathName === '/courts' ? 'active' : ''}`}
+									href='/courts'
+								>
+									Courts
+								</Link>
+							</li>
 						)}
 					</ul>
 					{user ? (


### PR DESCRIPTION
Changes:
* Create cards to show the current courts created and with 2 links:
  * court settings section
  * reservation section (the ID is not used for anything for now. In the future we will filter the events related to this court).

Extra:
* Move `Reservations` page to `reservations/[id]` to allow in a near future fetch the reservation related to a specific court.

![image](https://github.com/EzeLamar/sports-booking/assets/26080561/7cc47418-42ad-49dc-8ff2-bfe7cfe234fe)

