### PR TITLE
SB-60: Delete Reservation on FireStore by Calendar

### DIFF
--- a/app/(admin)/createReservation/page.tsx
+++ b/app/(admin)/createReservation/page.tsx
@@ -6,7 +6,10 @@ import 'react-toastify/dist/ReactToastify.css';
 import ReservationForm, {
 	Reservation,
 } from '../../components/Reservations/ReservationForm';
-import { createReservation } from '../../firebase/reservations/reservation';
+import {
+	createReservation,
+	deleteReservation,
+} from '../../firebase/reservations/reservation';
 import { getCourtRef } from '../../firebase/courts/courts';
 import hasErrorMessage from '../../utils/Error/ErrorHelper';
 
@@ -32,6 +35,21 @@ export default function CreateReservationPage() {
 						),
 					});
 					toast.success('Evento creado!', {
+						theme: 'colored',
+					});
+					return !!result;
+				} catch (error: unknown) {
+					if (hasErrorMessage(error)) {
+						toast.error(error.message, { theme: 'colored' });
+					}
+
+					throw error;
+				}
+			}}
+			handleDelete={async (id: string): Promise<boolean> => {
+				try {
+					const result = deleteReservation(id);
+					toast.success('Evento Eliminado!', {
 						theme: 'colored',
 					});
 					return !!result;

--- a/app/(admin)/reservations/[id]/page.tsx
+++ b/app/(admin)/reservations/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import Calendar from '@/app/components/UI/Calendar/Calendar';
 import {
 	createReservation,
+	deleteReservation,
 	getAllReservations,
 } from '@/app/firebase/reservations/reservation';
 import hasErrorMessage from '@/app/utils/Error/ErrorHelper';
@@ -79,6 +80,22 @@ export default function AdminPage({ params }: Props) {
 		}
 	};
 
+	const handleDeleteReservation = async (id: string): Promise<boolean> => {
+		try {
+			await deleteReservation(id);
+			toast.success('Reserva Eliminada!', {
+				theme: 'colored',
+			});
+			return true;
+		} catch (error: unknown) {
+			if (hasErrorMessage(error)) {
+				toast.error(error.message, { theme: 'colored' });
+			}
+
+			throw error;
+		}
+	};
+
 	const minHour = !showAll
 		? moment(`2024-04-04T${court?.openHour}:00`).toDate()
 		: null;
@@ -109,6 +126,7 @@ export default function AdminPage({ params }: Props) {
 					<Calendar
 						events={reservations}
 						handleAddEvent={handleAddReservation}
+						handleDeleteEvent={handleDeleteReservation}
 						minHour={minHour}
 						maxHour={maxHour}
 						defaultView={Views.DAY}

--- a/app/components/Reservations/ReservationForm.stories.tsx
+++ b/app/components/Reservations/ReservationForm.stories.tsx
@@ -28,11 +28,21 @@ const handleSubmit = (data: Reservation): Promise<boolean> =>
 		resolve(true);
 	});
 
+const handleDelete = (id: string): Promise<boolean> =>
+	new Promise(resolve => {
+		// eslint-disable-next-line no-console
+		console.log(id);
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify(id));
+		resolve(true);
+	});
+
 export const Enabled: Story = {
 	args: {
 		reservation: RESERVATION,
 		editable: true,
 		handleSubmit,
+		handleDelete,
 		minDate: RESERVATION_START_TIME,
 		maxDate: RESERVATION_START_TIME,
 	},
@@ -42,6 +52,7 @@ export const Disabled: Story = {
 	args: {
 		reservation: RESERVATION,
 		handleSubmit,
+		handleDelete,
 		minDate: RESERVATION_START_TIME,
 		maxDate: RESERVATION_START_TIME,
 	},
@@ -52,6 +63,7 @@ export const Empty: Story = {
 		reservation: EMPTY_RESERVATION,
 		editable: true,
 		handleSubmit,
+		handleDelete,
 		minDate: RESERVATION_START_TIME,
 		maxDate: RESERVATION_START_TIME,
 	},
@@ -62,6 +74,7 @@ export const MissingEndTime: Story = {
 		reservation: RESERVATION_WITHOUT_END_TIME,
 		editable: true,
 		handleSubmit,
+		handleDelete,
 		minDate: RESERVATION_START_TIME,
 		maxDate: RESERVATION_START_TIME,
 	},

--- a/app/components/Reservations/ReservationForm.tsx
+++ b/app/components/Reservations/ReservationForm.tsx
@@ -37,6 +37,7 @@ export type InitialReservation = {
 type Props = {
 	reservation: InitialReservation;
 	handleSubmit: (data: Reservation) => Promise<boolean>;
+	handleDelete: (id: string) => Promise<boolean>;
 	handleCancel: () => void;
 	minDate?: Date | null;
 	maxDate?: Date | null;
@@ -48,6 +49,7 @@ export default function ReservationForm({
 	reservation,
 	handleSubmit,
 	handleCancel = () => {},
+	handleDelete,
 	editable = false,
 	minDate = null,
 	maxDate = null,
@@ -86,6 +88,18 @@ export default function ReservationForm({
 		}
 	};
 
+	const onDelete = async (id: string): Promise<boolean> => {
+		try {
+			return await handleDelete(id);
+		} catch (error: unknown) {
+			if (hasErrorMessage(error)) {
+				toast.error(error.message, { theme: 'colored' });
+			}
+
+			return false;
+		}
+	};
+
 	const endHourValidation = (endTime: string, formValues: FieldValues) => {
 		if (endTime === formValues.startTime) {
 			return 'Fecha y hora igual a la de inicio';
@@ -99,45 +113,56 @@ export default function ReservationForm({
 	};
 
 	return (
-		<Form
-			title={showTitle ? LABELS.FORM_TITLE : null}
-			initialValues={initialValues}
-			handleSubmit={onSubmit}
-			handleCancel={handleCancel}
-			disabled={disabled}
-			setDisabled={setDisabled}
-		>
-			<Input
-				id='reservation-owner'
-				label={LABELS.OWNER}
-				name='owner'
-				placeholder={LABELS.OWNER}
-				{...TEXT_VALIDATOR}
-			/>
-			<Input
-				id='reservation-start-time'
-				label={LABELS.START_TIME}
-				name='startTime'
-				placeholder={LABELS.START_TIME}
-				min={min}
-				max={max}
-				{...DATETIME_VALIDATOR}
-			/>
-			<Input
-				id='reservation-end-time'
-				label={LABELS.END_TIME}
-				name='endTime'
-				placeholder={LABELS.END_TIME}
-				min={min}
-				max={max}
-				type={DATETIME_VALIDATOR.type}
-				validation={{
-					...DATETIME_VALIDATOR.validation,
-					validate: {
-						endGreaterThanStart: endHourValidation,
-					},
-				}}
-			/>
-		</Form>
+		<>
+			{initialValues.id && (
+				<button
+					className='position-absolute top-0 end-0 mt-3 me-3 p-2 btn btn-danger bi bi-trash-fill'
+					type='button'
+					onClick={() => onDelete(initialValues.id ?? '')}
+				>
+					Borrar
+				</button>
+			)}
+			<Form
+				title={showTitle ? LABELS.FORM_TITLE : null}
+				initialValues={initialValues}
+				handleSubmit={onSubmit}
+				handleCancel={handleCancel}
+				disabled={disabled}
+				setDisabled={setDisabled}
+			>
+				<Input
+					id='reservation-owner'
+					label={LABELS.OWNER}
+					name='owner'
+					placeholder={LABELS.OWNER}
+					{...TEXT_VALIDATOR}
+				/>
+				<Input
+					id='reservation-start-time'
+					label={LABELS.START_TIME}
+					name='startTime'
+					placeholder={LABELS.START_TIME}
+					min={min}
+					max={max}
+					{...DATETIME_VALIDATOR}
+				/>
+				<Input
+					id='reservation-end-time'
+					label={LABELS.END_TIME}
+					name='endTime'
+					placeholder={LABELS.END_TIME}
+					min={min}
+					max={max}
+					type={DATETIME_VALIDATOR.type}
+					validation={{
+						...DATETIME_VALIDATOR.validation,
+						validate: {
+							endGreaterThanStart: endHourValidation,
+						},
+					}}
+				/>
+			</Form>
+		</>
 	);
 }

--- a/app/components/Reservations/ReservationModal.stories.tsx
+++ b/app/components/Reservations/ReservationModal.stories.tsx
@@ -39,6 +39,17 @@ const handleSubmit = (data: Reservation): Promise<boolean> =>
 		resolve(true);
 	});
 
+const handleDelete = (id: string): Promise<boolean> =>
+	new Promise(resolve => {
+		// eslint-disable-next-line no-console
+		console.log(id);
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify(id));
+		// eslint-disable-next-line no-alert
+		alert(JSON.stringify('se cierra el modal'));
+		resolve(true);
+	});
+
 const handleClose = (): void => {
 	// eslint-disable-next-line no-alert
 	alert(JSON.stringify('se cierra el modal'));
@@ -51,6 +62,7 @@ export const Enabled: Story = {
 		editable: true,
 		handleSubmit,
 		handleClose,
+		handleDelete,
 		handleCancel: handleClose,
 		minDate: reservationStartTime,
 		maxDate: reservationStartTime,
@@ -62,6 +74,7 @@ export const Disabled: Story = {
 		show: true,
 		reservation: RESERVATION,
 		handleSubmit,
+		handleDelete,
 		handleClose,
 		minDate: reservationStartTime,
 		maxDate: reservationStartTime,
@@ -75,6 +88,7 @@ export const Empty: Story = {
 		editable: true,
 		handleSubmit,
 		handleClose,
+		handleDelete,
 		handleCancel: handleClose,
 		minDate: reservationStartTime,
 		maxDate: reservationStartTime,
@@ -87,6 +101,7 @@ export const MissingEndTime: Story = {
 		reservation: RESERVATION_WITHOUT_END_TIME,
 		editable: true,
 		handleSubmit,
+		handleDelete,
 		handleCancel: handleClose,
 		minDate: reservationStartTime,
 		maxDate: reservationStartTime,

--- a/app/components/Reservations/ReservationModal.tsx
+++ b/app/components/Reservations/ReservationModal.tsx
@@ -14,6 +14,7 @@ type Props = {
 	reservation: InitialReservation;
 	handleClose: () => void;
 	handleSubmit: (data: Reservation) => Promise<boolean>;
+	handleDelete: (id: string) => Promise<boolean>;
 	handleCancel: () => void;
 	minDate?: Date | null;
 	maxDate?: Date | null;
@@ -25,6 +26,7 @@ export default function ReservationModal({
 	reservation,
 	handleSubmit,
 	handleClose,
+	handleDelete,
 	handleCancel = () => {},
 	editable = false,
 	minDate = null,
@@ -41,6 +43,7 @@ export default function ReservationModal({
 				reservation={reservation}
 				handleSubmit={handleSubmit}
 				handleCancel={handleCancel}
+				handleDelete={handleDelete}
 				editable={editable}
 				minDate={minDate}
 				maxDate={maxDate}

--- a/app/components/UI/Calendar/Calendar.stories.tsx
+++ b/app/components/UI/Calendar/Calendar.stories.tsx
@@ -80,10 +80,17 @@ const handleAddEvent = (_data: Reservation): Promise<string> =>
 		resolve('1');
 	});
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const handleDeleteEvent = (_id: string): Promise<boolean> =>
+	new Promise(resolve => {
+		resolve(true);
+	});
+
 export const Default: Story = {
 	args: {
 		events,
 		handleAddEvent,
+		handleDeleteEvent,
 		minHour,
 		maxHour,
 		defaultDate,

--- a/app/components/UI/Calendar/Calendar.tsx
+++ b/app/components/UI/Calendar/Calendar.tsx
@@ -84,6 +84,7 @@ const customEventPropGetter = (event: TEvent) => {
 type Props = {
 	events: TEvent[];
 	handleAddEvent: (data: Reservation) => Promise<string>;
+	handleDeleteEvent: (id: string) => Promise<boolean>;
 	minHour?: Date | null;
 	maxHour?: Date | null;
 	defaultDate?: Date;
@@ -94,6 +95,7 @@ type Props = {
 export default function Calendar({
 	events,
 	handleAddEvent,
+	handleDeleteEvent,
 	minHour = null,
 	maxHour = null,
 	defaultDate = new Date(),
@@ -151,6 +153,15 @@ export default function Calendar({
 			}
 		});
 
+	const onDelete = (id: string): Promise<boolean> =>
+		new Promise(resolve => {
+			handleDeleteEvent(id).then(() => {
+				setEvents(myEvents.filter(event => event.data.id !== id));
+				setShowModal(false);
+				resolve(true);
+			});
+		});
+
 	const onSelectSlot = useCallback(({ start, end }: SelectEventSlotProp) => {
 		const reservation: InitialReservation = {
 			id: null,
@@ -201,6 +212,7 @@ export default function Calendar({
 					reservation={selected}
 					handleClose={() => setShowModal(false)}
 					handleSubmit={onSubmit}
+					handleDelete={onDelete}
 					handleCancel={() => setShowModal(false)}
 					editable={editable}
 					minDate={selected ? selected.startTime : null}

--- a/app/components/UI/Form/Form.css
+++ b/app/components/UI/Form/Form.css
@@ -1,8 +1,3 @@
-.form__buttons {
-	display: flex;
-	flex-wrap: wrap;
-}
-
 .form__button {
 	margin: 2px;
 }

--- a/app/components/UI/Form/Form.tsx
+++ b/app/components/UI/Form/Form.tsx
@@ -69,7 +69,7 @@ export default function Form({
 				<fieldset disabled={disabled}>
 					{children}
 					{!disabled && (
-						<div className='form__buttons'>
+						<div className='d-flex flex-start'>
 							<input
 								type='submit'
 								className='btn btn-primary form__button'

--- a/app/firebase/reservations/reservation.ts
+++ b/app/firebase/reservations/reservation.ts
@@ -5,6 +5,7 @@ import {
 	collection,
 	getDocs,
 	addDoc,
+	deleteDoc,
 } from 'firebase/firestore';
 import {
 	ReservationDraft,
@@ -99,4 +100,17 @@ export async function createReservation(
 	const docRef = await addDoc(colRef, reservation);
 
 	return docRef.id;
+}
+
+export async function deleteReservation(id: string): Promise<boolean> {
+	const db = getFirestore(firebaseApp);
+	const docRef = doc(
+		db,
+		process.env.NEXT_PUBLIC_RESERVATIONS_COLLECTION ??
+			'NEXT_PUBLIC_RESERVATIONS_COLLECTION',
+		id
+	);
+	await deleteDoc(docRef);
+
+	return true;
 }


### PR DESCRIPTION
Changes:
* Allows to delete reservations on Firestore by the Reservation Calendar.
* Add "Remove Button" on ReservationForm. 
![image](https://github.com/EzeLamar/sports-booking/assets/26080561/5a92ac7c-bae0-435d-872b-47146ef4fffb)
