### PR TITLE
SB-59: update reservations from UI

### DIFF
--- a/app/(admin)/reservations/[id]/page.tsx
+++ b/app/(admin)/reservations/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
 	createReservation,
 	deleteReservation,
 	getAllReservations,
+	updateReservation,
 } from '@/app/firebase/reservations/reservation';
 import hasErrorMessage from '@/app/utils/Error/ErrorHelper';
 import { toast } from 'react-toastify';
@@ -96,6 +97,35 @@ export default function AdminPage({ params }: Props) {
 		}
 	};
 
+	const handleUpdateReservation = async (
+		data: ReservationForm
+	): Promise<boolean> => {
+		try {
+			if (data.id === null) {
+				throw new Error('missingReservationId');
+			} else {
+				const reservation: Reservation = {
+					id: data.id,
+					owner: data.owner,
+					startTime: new Date(data.startTime),
+					endTime: new Date(data.endTime),
+					court: getCourtRef(params.id),
+				};
+				await updateReservation(reservation);
+				toast.success('Reserva modificada!', {
+					theme: 'colored',
+				});
+				return true;
+			}
+		} catch (error: unknown) {
+			if (hasErrorMessage(error)) {
+				toast.error(error.message, { theme: 'colored' });
+			}
+
+			throw error;
+		}
+	};
+
 	const minHour = !showAll
 		? moment(`2024-04-04T${court?.openHour}:00`).toDate()
 		: null;
@@ -127,6 +157,7 @@ export default function AdminPage({ params }: Props) {
 						events={reservations}
 						handleAddEvent={handleAddReservation}
 						handleDeleteEvent={handleDeleteReservation}
+						handleUpdateEvent={handleUpdateReservation}
 						minHour={minHour}
 						maxHour={maxHour}
 						defaultView={Views.DAY}

--- a/app/components/UI/Calendar/Calendar.stories.tsx
+++ b/app/components/UI/Calendar/Calendar.stories.tsx
@@ -86,11 +86,18 @@ const handleDeleteEvent = (_id: string): Promise<boolean> =>
 		resolve(true);
 	});
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const handleUpdateEvent = (_data: Reservation): Promise<boolean> =>
+	new Promise(resolve => {
+		resolve(true);
+	});
+
 export const Default: Story = {
 	args: {
 		events,
 		handleAddEvent,
 		handleDeleteEvent,
+		handleUpdateEvent,
 		minHour,
 		maxHour,
 		defaultDate,

--- a/app/components/UI/Calendar/Calendar.tsx
+++ b/app/components/UI/Calendar/Calendar.tsx
@@ -85,6 +85,7 @@ type Props = {
 	events: TEvent[];
 	handleAddEvent: (data: Reservation) => Promise<string>;
 	handleDeleteEvent: (id: string) => Promise<boolean>;
+	handleUpdateEvent: (data: Reservation) => Promise<boolean>;
 	minHour?: Date | null;
 	maxHour?: Date | null;
 	defaultDate?: Date;
@@ -96,6 +97,7 @@ export default function Calendar({
 	events,
 	handleAddEvent,
 	handleDeleteEvent,
+	handleUpdateEvent,
 	minHour = null,
 	maxHour = null,
 	defaultDate = new Date(),
@@ -147,9 +149,26 @@ export default function Calendar({
 					resolve(true);
 				});
 			} else {
-				// TODO: Service call to Edit the Reservation on FireStore
-				setShowModal(false);
-				resolve(true);
+				handleUpdateEvent(data).then(() => {
+					const updatedEvent: TEvent = {
+						start: data.startTime,
+						end: data.endTime,
+						title: 'Test Title',
+						data: {
+							id: data.id ?? '', // TODO: this will be fixed in a future update
+							type: 'match',
+							owner: data.owner,
+						},
+						desc: '',
+					};
+
+					setEvents([
+						...myEvents.filter(event => event.data.id !== data.id),
+						updatedEvent,
+					]);
+					setShowModal(false);
+					resolve(true);
+				});
 			}
 		});
 

--- a/app/firebase/reservations/reservation.ts
+++ b/app/firebase/reservations/reservation.ts
@@ -6,6 +6,7 @@ import {
 	getDocs,
 	addDoc,
 	deleteDoc,
+	updateDoc,
 } from 'firebase/firestore';
 import {
 	ReservationDraft,
@@ -112,5 +113,28 @@ export async function deleteReservation(id: string): Promise<boolean> {
 	);
 	await deleteDoc(docRef);
 
+	return true;
+}
+
+export async function updateReservation(
+	reservationData: Reservation
+): Promise<boolean> {
+	const db = getFirestore(firebaseApp);
+	const docRef = doc(
+		db,
+		process.env.NEXT_PUBLIC_RESERVATIONS_COLLECTION ??
+			'NEXT_PUBLIC_RESERVATIONS_COLLECTION',
+		reservationData.id
+	);
+
+	await updateDoc(docRef, {
+		court: reservationData.court,
+		owner: reservationData.owner,
+		startTime: reservationData.startTime,
+		duration: getDurationFromStartTimeAndEndTimeInMinutes(
+			reservationData.startTime,
+			reservationData.endTime
+		),
+	});
 	return true;
 }


### PR DESCRIPTION
When opening a pre-existent reservation in the Calendar, at the moment of saving, the reservation shouldb e updated instead oreating a brand new one.

![image](https://github.com/EzeLamar/sports-booking/assets/90333087/018a81c2-8eb0-4658-8f8f-81321609238c)
