### PR TITLE
SB-81: Allow create multiple reservation ocurrences

### DIFF
--- a/app/components/Reservations/ReservationModal.tsx
+++ b/app/components/Reservations/ReservationModal.tsx
@@ -13,7 +13,7 @@ type Props = {
 	show: boolean;
 	reservation: InitialReservation;
 	handleClose: () => void;
-	handleSubmit: (data: Reservation) => Promise<boolean>;
+	handleSubmit: (data: Reservation, ocurrences: number) => Promise<boolean>;
 	handleDelete: (id: string) => Promise<boolean>;
 	handleCancel: () => void;
 	minDate?: Date | null;

--- a/app/components/UI/Calendar/Calendar.stories.tsx
+++ b/app/components/UI/Calendar/Calendar.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../firebase/reservations/model';
 import Calendar from './Calendar';
 import { Reservation } from '../../Reservations/ReservationForm';
+import { TEvent } from './model';
 
 const meta = {
 	title: 'UI/Calendar',
@@ -95,6 +96,27 @@ const handleAddEvent = (_data: Reservation): Promise<string> =>
 	});
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
+const handleAddRegularEvent = (
+	data: Reservation,
+	ocurrences: number
+): Promise<TEvent[]> =>
+	new Promise(resolve => {
+		const regularEvents = Array.from({ length: ocurrences }, (_, index) => ({
+			start: data.startTime,
+			end: data.endTime,
+			title: `Event ${index + 1}`,
+			data: {
+				id: `${index + 1}`,
+				type: data.type,
+				owner: data.owner,
+				price: data.price,
+				status: data.status,
+			},
+		}));
+		resolve(regularEvents);
+	});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const handleDeleteEvent = (_id: string): Promise<boolean> =>
 	new Promise(resolve => {
 		resolve(true);
@@ -110,6 +132,7 @@ export const Default: Story = {
 	args: {
 		events,
 		handleAddEvent,
+		handleAddRegularEvent,
 		handleDeleteEvent,
 		handleUpdateEvent,
 		minHour,


### PR DESCRIPTION
Changes:
* Add `Regular Reservation Toggle` to allow or disable the creation of multiple reservations with the same data increasing the date 7 days later per each one.
* Show `occurrences number input field` when the toggle is on to indicate the number of occurrences to create during the Regular Reservation creation.
* Add new firebase service to create RegularReservations by the first reservation and the number of occurrences to create (greater than 1).

Extra:
* Refactor `onSubmit` on the Calendar Component to improve legibility.

![image](https://github.com/EzeLamar/sports-booking/assets/26080561/818dff6b-2ab9-4f9c-8568-28f536e6f77b)

![image](https://github.com/EzeLamar/sports-booking/assets/26080561/e71ddd1c-f016-4e0a-97e3-abce716eb059)
